### PR TITLE
Fix Object of type float32 is not JSON serializable error.

### DIFF
--- a/api.py
+++ b/api.py
@@ -12,7 +12,7 @@ model = Ner("out_base")
 def predict():
     text = request.json["text"]
     try:
-        out = model.predict(text)
+        out = str(model.predict(text))
         return jsonify({"result":out})
     except Exception as e:
         print(e)


### PR DESCRIPTION
For some reason running the api.py resulted in "Object of type float32 is not JSON serializable" error in my setup. I propose this quick fix.